### PR TITLE
Fix error 'too few arguments to function mid_istream_open_callbacks'

### DIFF
--- a/interfaces/IFusionSoundMusicProvider/ifusionsoundmusicprovider_timidity.c
+++ b/interfaces/IFusionSoundMusicProvider/ifusionsoundmusicprovider_timidity.c
@@ -363,7 +363,7 @@ IFusionSoundMusicProvider_Timidity_PlayToStream(
      Timidity_Stop( data, false );
      
      direct_stream_seek( data->st, 0 );
-     stream = mid_istream_open_callbacks( read_callback, close_callback, data );
+     stream = mid_istream_open_callbacks( read_callback, mid_istream_seek, mid_istream_tell, close_callback, data );
      if (!stream) {
           D_ERROR( "IFusionSoundMusicProvider_Timidity: couldn't open input stream!\n" );
           pthread_mutex_unlock( &data->lock );
@@ -510,7 +510,7 @@ IFusionSoundMusicProvider_Timidity_PlayToBuffer(
      Timidity_Stop( data, false );
 
      direct_stream_seek( data->st, 0 );
-     stream = mid_istream_open_callbacks( read_callback, close_callback, data );
+     stream = mid_istream_open_callbacks( read_callback, mid_istream_seek, mid_istream_tell, close_callback, data );
      if (!stream) {
           D_ERROR( "IFusionSoundMusicProvider_Timidity: couldn't open input stream!\n" );
           pthread_mutex_unlock( &data->lock );


### PR DESCRIPTION
As of LibTiMidity 0.2.0, the `mid_istream_open_callbacks` function takes two new parameters, `seekfn` and `tellfn`. This pull request uses the mid_istream_seek and mid_istream_tell functions there.

From the [0.2.0 release announcement](https://sourceforge.net/p/libtimidity/news/2016/09/libtimidity-new-stable-version-020/):
>stream.c, api change: added mid_istream_seek and mid_istream_tell to
the mid_istream_* api. added seek and tell funcs to the _MidIStream
structure. mid_istream_open_callbacks() is changed now accepts these
callbacks.